### PR TITLE
🔒 Fix insecure deserialization in persistent DAG engine

### DIFF
--- a/lib/storage/persistent_dag_engine.ex
+++ b/lib/storage/persistent_dag_engine.ex
@@ -77,7 +77,7 @@ defmodule Kylix.Storage.PersistentDAGEngine do
       # Load existing metadata
       metadata_path
       |> File.read!()
-      |> :erlang.binary_to_term()
+      |> :erlang.binary_to_term([:safe])
     else
       # Initialize new metadata
       %{
@@ -124,7 +124,7 @@ defmodule Kylix.Storage.PersistentDAGEngine do
           node_data =
             Path.join(nodes_dir, file)
             |> File.read!()
-            |> :erlang.binary_to_term()
+            |> :erlang.binary_to_term([:safe])
 
           Map.put(acc, node_id, node_data)
         end)
@@ -144,7 +144,7 @@ defmodule Kylix.Storage.PersistentDAGEngine do
           edge_data =
             Path.join(edges_dir, file)
             |> File.read!()
-            |> :erlang.binary_to_term()
+            |> :erlang.binary_to_term([:safe])
 
           case edge_data do
             {from_id, to_id, label} ->
@@ -262,7 +262,7 @@ defmodule Kylix.Storage.PersistentDAGEngine do
           # Read from disk and parse
           node_data =
             File.read!(node_path)
-            |> :erlang.binary_to_term()
+            |> :erlang.binary_to_term([:safe])
 
           # Update cache with this node
           new_cache = %{state.cache | nodes: Map.put(state.cache.nodes, node_id, node_data)}
@@ -301,7 +301,7 @@ defmodule Kylix.Storage.PersistentDAGEngine do
             node_data =
               Path.join([state.db_path, @nodes_dir, file])
               |> File.read!()
-              |> :erlang.binary_to_term()
+              |> :erlang.binary_to_term([:safe])
 
             {node_id, node_data}
           end


### PR DESCRIPTION
🎯 **What:** Fixed an insecure deserialization vulnerability in `lib/storage/persistent_dag_engine.ex` where `:erlang.binary_to_term/1` was used to decode binary data from files on disk.

⚠️ **Risk:** The previous implementation used `:erlang.binary_to_term/1` without the `[:safe]` option. In Erlang/Elixir, dynamically converting untrusted binaries to terms can allow an attacker to exhaust the VM's atom table limit (atom exhaustion vulnerability), which can result in a Denial of Service (DoS) by crashing the Erlang VM. This could happen if a malicious user is able to inject arbitrary binary files into the database directory used by the DAG engine.

🛡️ **Solution:** Updated all usages of `:erlang.binary_to_term/1` to `:erlang.binary_to_term([:safe])` in `lib/storage/persistent_dag_engine.ex`. The `[:safe]` option ensures that no new atoms are created during deserialization, preventing the vulnerability without impacting functionality, provided that all expected atoms have already been declared in the system (which is generally the case for standard operations).

---
*PR created automatically by Jules for task [12751077353079879356](https://jules.google.com/task/12751077353079879356) started by @anusornc*