### PR TITLE
Fix: remove duplicate comment in transaction_queue_test.exs

### DIFF
--- a/test/server/transaction_queue_test.exs
+++ b/test/server/transaction_queue_test.exs
@@ -127,7 +127,6 @@ defmodule Kylix.Server.TransactionQueueTest do
   end
 
   # Fix for the failing test
-  # Fix for the failing test
   test "transaction status updates via direct message", %{queue_pid: pid} do
     # Generate a reference directly instead of submitting a transaction
     ref = make_ref()


### PR DESCRIPTION
Removed duplicate comment as requested.

---
*PR created automatically by Jules for task [14886061610282479554](https://jules.google.com/task/14886061610282479554) started by @anusornc*