### PR TITLE
🔒 Fix insecure deserialization in DAG storage engine

### DIFF
--- a/lib/storage/persistent_dag_engine.ex
+++ b/lib/storage/persistent_dag_engine.ex
@@ -77,7 +77,7 @@ defmodule Kylix.Storage.PersistentDAGEngine do
       # Load existing metadata
       metadata_path
       |> File.read!()
-      |> :erlang.binary_to_term()
+      |> :erlang.binary_to_term([:safe])
     else
       # Initialize new metadata
       %{
@@ -124,7 +124,7 @@ defmodule Kylix.Storage.PersistentDAGEngine do
           node_data =
             Path.join(nodes_dir, file)
             |> File.read!()
-            |> :erlang.binary_to_term()
+            |> :erlang.binary_to_term([:safe])
 
           Map.put(acc, node_id, node_data)
         end)
@@ -144,7 +144,7 @@ defmodule Kylix.Storage.PersistentDAGEngine do
           edge_data =
             Path.join(edges_dir, file)
             |> File.read!()
-            |> :erlang.binary_to_term()
+            |> :erlang.binary_to_term([:safe])
 
           case edge_data do
             {from_id, to_id, label} ->
@@ -262,7 +262,7 @@ defmodule Kylix.Storage.PersistentDAGEngine do
           # Read from disk and parse
           node_data =
             File.read!(node_path)
-            |> :erlang.binary_to_term()
+            |> :erlang.binary_to_term([:safe])
 
           # Update cache with this node
           new_cache = %{state.cache | nodes: Map.put(state.cache.nodes, node_id, node_data)}
@@ -301,7 +301,7 @@ defmodule Kylix.Storage.PersistentDAGEngine do
             node_data =
               Path.join([state.db_path, @nodes_dir, file])
               |> File.read!()
-              |> :erlang.binary_to_term()
+              |> :erlang.binary_to_term([:safe])
 
             {node_id, node_data}
           end

--- a/test/storage/persistent_dag_engine_test.exs
+++ b/test/storage/persistent_dag_engine_test.exs
@@ -57,7 +57,7 @@ defmodule Kylix.Storage.PersistentDAGEngineTest do
       stored_data =
         node_path
         |> File.read!()
-        |> :erlang.binary_to_term()
+        |> :erlang.binary_to_term([:safe])
 
       assert stored_data == data
     end
@@ -125,7 +125,7 @@ defmodule Kylix.Storage.PersistentDAGEngineTest do
       stored_edge =
         edge_path
         |> File.read!()
-        |> :erlang.binary_to_term()
+        |> :erlang.binary_to_term([:safe])
 
       assert stored_edge == {"source", "target", "connects"}
 


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
This PR patches an insecure deserialization vulnerability in the DAG storage engine. The function `:erlang.binary_to_term/1` was being called without the `[:safe]` option when loading nodes and edges from disk. 

⚠️ **Risk:** The potential impact if left unfixed
In Erlang/Elixir, deserializing binary terms without the `[:safe]` option allows the creation of arbitrary atoms. Since the atom table is not garbage-collected and has a strict upper limit, an attacker could provide maliciously crafted binaries to exhaust the atom table, leading to a Denial of Service (DoS) attack. It could also lead to arbitrary code execution if chained with other vulnerabilities.

🛡️ **Solution:** How the fix addresses the vulnerability
The solution involves adding the `[:safe]` option to all `:erlang.binary_to_term` calls (`:erlang.binary_to_term(..., [:safe])`) in `lib/storage/persistent_dag_engine.ex` and `test/storage/persistent_dag_engine_test.exs`. This instructs the VM to only allow atoms that already exist in the runtime, safely dropping untrusted ones and effectively preventing atom exhaustion vulnerabilities without disrupting regular workflows where the expected atoms are already in memory.

---
*PR created automatically by Jules for task [18053493174420841178](https://jules.google.com/task/18053493174420841178) started by @anusornc*