### PR TITLE
🧹 Remove leftover debugging statements from sparql_parser.ex

### DIFF
--- a/lib/query/sparql_parser.ex
+++ b/lib/query/sparql_parser.ex
@@ -321,14 +321,11 @@ defmodule Kylix.Query.SparqlParser do
   Parses a SPARQL query string into a structured query representation.
   """
   def parse(query) do
-    IO.inspect(query, label: "Raw query input to parser")
     try do
       normalized_query = normalize_query(query)
       Logger.debug("Parsing query: #{normalized_query}")
       case parse_query(normalized_query) do
         {:ok, parsed, "", _, _, _} ->
-          IO.inspect(parsed, label: "Parsed before conversion")
-          IO.inspect(parsed, label: "Parsed")
           query_structure = convert_to_query_structure(parsed)
           {:ok, query_structure}
 


### PR DESCRIPTION
🎯 **What:** Removed leftover `IO.inspect` calls in `lib/query/sparql_parser.ex`.
💡 **Why:** `IO.inspect` is typically used for debugging and clutters standard output. Removing them improves the codebase's maintainability and readability by keeping production code clean.
✅ **Verification:** Verified that tests pass via `mix test` with Elixir 1.18.2 to ensure there were no regressions introduced.
✨ **Result:** Improved code health and cleaner log/console output by eliminating stray debug statements without changing the underlying behavior of `parse/1`.

---
*PR created automatically by Jules for task [8524689734161119077](https://jules.google.com/task/8524689734161119077) started by @anusornc*