### PR TITLE
🔒 Fix insecure deserialization in DAGEngine

### DIFF
--- a/lib/storage/persistent_dag_engine.ex
+++ b/lib/storage/persistent_dag_engine.ex
@@ -77,7 +77,7 @@ defmodule Kylix.Storage.PersistentDAGEngine do
       # Load existing metadata
       metadata_path
       |> File.read!()
-      |> :erlang.binary_to_term()
+      |> :erlang.binary_to_term([:safe])
     else
       # Initialize new metadata
       %{
@@ -124,7 +124,7 @@ defmodule Kylix.Storage.PersistentDAGEngine do
           node_data =
             Path.join(nodes_dir, file)
             |> File.read!()
-            |> :erlang.binary_to_term()
+            |> :erlang.binary_to_term([:safe])
 
           Map.put(acc, node_id, node_data)
         end)
@@ -144,7 +144,7 @@ defmodule Kylix.Storage.PersistentDAGEngine do
           edge_data =
             Path.join(edges_dir, file)
             |> File.read!()
-            |> :erlang.binary_to_term()
+            |> :erlang.binary_to_term([:safe])
 
           case edge_data do
             {from_id, to_id, label} ->
@@ -262,7 +262,7 @@ defmodule Kylix.Storage.PersistentDAGEngine do
           # Read from disk and parse
           node_data =
             File.read!(node_path)
-            |> :erlang.binary_to_term()
+            |> :erlang.binary_to_term([:safe])
 
           # Update cache with this node
           new_cache = %{state.cache | nodes: Map.put(state.cache.nodes, node_id, node_data)}
@@ -301,7 +301,7 @@ defmodule Kylix.Storage.PersistentDAGEngine do
             node_data =
               Path.join([state.db_path, @nodes_dir, file])
               |> File.read!()
-              |> :erlang.binary_to_term()
+              |> :erlang.binary_to_term([:safe])
 
             {node_id, node_data}
           end

--- a/test/storage/persistent_dag_engine_test.exs
+++ b/test/storage/persistent_dag_engine_test.exs
@@ -57,7 +57,7 @@ defmodule Kylix.Storage.PersistentDAGEngineTest do
       stored_data =
         node_path
         |> File.read!()
-        |> :erlang.binary_to_term()
+        |> :erlang.binary_to_term([:safe])
 
       assert stored_data == data
     end
@@ -125,7 +125,7 @@ defmodule Kylix.Storage.PersistentDAGEngineTest do
       stored_edge =
         edge_path
         |> File.read!()
-        |> :erlang.binary_to_term()
+        |> :erlang.binary_to_term([:safe])
 
       assert stored_edge == {"source", "target", "connects"}
 


### PR DESCRIPTION
🎯 **What:** Adds `[:safe]` option to all `:erlang.binary_to_term/1` calls in `PersistentDAGEngine`.
⚠️ **Risk:** Unsafe deserialization allows malicious payloads to create arbitrary atoms, which could exhaust the Erlang atom table and crash the node (Denial of Service).
🛡️ **Solution:** By passing the `[:safe]` option, the deserializer is prevented from instantiating new atoms, protecting the application from atom exhaustion vulnerabilities.

---
*PR created automatically by Jules for task [14837854581510715821](https://jules.google.com/task/14837854581510715821) started by @anusornc*