### PR TITLE
🧪 Add test coverage for Consensus.check_coordinator_running

### DIFF
--- a/test/consensus_test.exs
+++ b/test/consensus_test.exs
@@ -1,0 +1,24 @@
+defmodule Kylix.ConsensusTest do
+  use ExUnit.Case
+
+  alias Kylix.Consensus
+
+  describe "check_coordinator_running/0" do
+    test "returns true when ValidatorCoordinator is running" do
+      # Since Application.ensure_all_started(:kylix) is in test_helper.exs,
+      # ValidatorCoordinator should be running globally.
+      assert Consensus.check_coordinator_running() == true
+    end
+
+    test "returns false when ValidatorCoordinator is stopped" do
+      # Temporarily stop the ValidatorCoordinator
+      Supervisor.terminate_child(Kylix.Supervisor, Kylix.Consensus.ValidatorCoordinator)
+
+      # The process is dead, so it should return false
+      assert Consensus.check_coordinator_running() == false
+
+      # Restart the coordinator for subsequent tests
+      Supervisor.restart_child(Kylix.Supervisor, Kylix.Consensus.ValidatorCoordinator)
+    end
+  end
+end


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the missing test file for the `Kylix.Consensus` module, specifically `check_coordinator_running/0`.
📊 **Coverage:** What scenarios are now tested:
- When the `ValidatorCoordinator` is running (`true` path).
- When the `ValidatorCoordinator` is stopped (`false` path).
✨ **Result:** The improvement in test coverage increases the reliability of the `Consensus` module by verifying that process state checks function as intended.

---
*PR created automatically by Jules for task [16537630594469157237](https://jules.google.com/task/16537630594469157237) started by @anusornc*