### PR TITLE
🧹 Refactor load_benchmark_data in router to improve maintainability

### DIFF
--- a/lib/api/router.ex
+++ b/lib/api/router.ex
@@ -269,78 +269,65 @@ defmodule Kylix.API.Router do
 
   # Load transaction benchmark data from JSON files
   defp load_benchmark_data do
-    # Path to benchmark directory
     benchmark_dir = "data/benchmark"
 
-    # Check if directory exists
     if File.exists?(benchmark_dir) && File.dir?(benchmark_dir) do
-      # List all JSON files in the directory
-      files =
-        File.ls!(benchmark_dir)
-        |> Enum.filter(&String.ends_with?(&1, ".json"))
-        |> Enum.sort()
-        # Get newest first
-        |> Enum.reverse()
-        # Take only the 5 most recent
-        |> Enum.take(5)
-
-      # Return empty if no files
-      if files == [] do
-        %{
-          results: [],
-          latest: nil
-        }
-      else
-        # Read and parse the most recent file
-        latest_file = hd(files)
-        latest_path = Path.join(benchmark_dir, latest_file)
-
-        latest_data =
-          case File.read(latest_path) do
-            {:ok, content} ->
-              case Jason.decode(content) do
-                {:ok, parsed} -> parsed
-                _ -> %{}
-              end
-
-            _ ->
-              %{}
-          end
-
-        # Read all files for time series data
-        all_results =
-          Enum.map(files, fn file ->
-            path = Path.join(benchmark_dir, file)
-            timestamp = extract_timestamp_from_filename(file)
-
-            case File.read(path) do
-              {:ok, content} ->
-                case Jason.decode(content) do
-                  {:ok, parsed} ->
-                    Map.put(parsed, "timestamp", timestamp)
-
-                  _ ->
-                    nil
-                end
-
-              _ ->
-                nil
-            end
-          end)
-          |> Enum.filter(&(&1 != nil))
-
-        # Return structured data
-        %{
-          results: all_results,
-          latest: latest_data
-        }
-      end
+      benchmark_dir
+      |> get_recent_benchmark_files()
+      |> load_benchmark_files(benchmark_dir)
     else
-      # Directory doesn't exist
-      %{
-        results: [],
-        latest: nil
-      }
+      empty_benchmark_data()
+    end
+  end
+
+  defp empty_benchmark_data do
+    %{results: [], latest: nil}
+  end
+
+  defp get_recent_benchmark_files(dir) do
+    File.ls!(dir)
+    |> Enum.filter(&String.ends_with?(&1, ".json"))
+    |> Enum.sort()
+    |> Enum.reverse()
+    |> Enum.take(5)
+  end
+
+  defp load_benchmark_files([], _dir), do: empty_benchmark_data()
+
+  defp load_benchmark_files([latest | _] = files, dir) do
+    latest_data = parse_benchmark_file_with_default(Path.join(dir, latest), %{})
+
+    all_results =
+      files
+      |> Enum.map(&parse_benchmark_series_file(&1, dir))
+      |> Enum.filter(&(&1 != nil))
+
+    %{results: all_results, latest: latest_data}
+  end
+
+  defp parse_benchmark_file(path) do
+    with {:ok, content} <- File.read(path),
+         {:ok, parsed} <- Jason.decode(content) do
+      {:ok, parsed}
+    else
+      _ -> :error
+    end
+  end
+
+  defp parse_benchmark_file_with_default(path, default) do
+    case parse_benchmark_file(path) do
+      {:ok, parsed} -> parsed
+      :error -> default
+    end
+  end
+
+  defp parse_benchmark_series_file(file, dir) do
+    path = Path.join(dir, file)
+    timestamp = extract_timestamp_from_filename(file)
+
+    case parse_benchmark_file(path) do
+      {:ok, parsed} -> Map.put(parsed, "timestamp", timestamp)
+      :error -> nil
     end
   end
 


### PR DESCRIPTION
🎯 **What:** The `load_benchmark_data/0` function in `lib/api/router.ex` was refactored. The large function body parsing and listing directory contents was broken down into smaller, composable helper functions like `get_recent_benchmark_files/1`, `load_benchmark_files/2`, and `parse_benchmark_file/1`.

💡 **Why:** Functions longer than 50 lines with deep nesting are hard to read and maintain. By extracting private helper functions, the logic is much more self-documenting and adheres to Elixir's idiomatic style (using `with`, `case`, and pattern matching on function heads).

✅ **Verification:** Verified by manually reviewing the refactored functions to ensure exactly the same functional outputs. Ran the test suite `mix test` to confirm there are no broken dependencies or regressions caused by this API refactoring. Confirmed exact match in Git diffs.

✨ **Result:** The `lib/api/router.ex` code is considerably cleaner, easier to comprehend, and more maintainable for future feature changes.

---
*PR created automatically by Jules for task [557819187308859774](https://jules.google.com/task/557819187308859774) started by @anusornc*