### PR TITLE
Fix transaction status updates

### DIFF
--- a/lib/server/transaction_queue.ex
+++ b/lib/server/transaction_queue.ex
@@ -362,10 +362,13 @@ defmodule Kylix.Server.TransactionQueue do
     Logger.info("Received transaction result for ref #{inspect(ref)}: #{inspect(result)}")
 
     # Update transaction status for this specific reference
-    updated_statuses = Map.put(state.transaction_statuses, ref, %{
+    existing_status = Map.get(state.transaction_statuses, ref, %{})
+
+    updated_statuses = Map.put(state.transaction_statuses, ref, existing_status |> Map.merge(%{
+      status: :completed,
       result: result,
       completed_at: now
-    })
+    }))
 
     # Update stats based on result
     new_stats = case result do
@@ -476,10 +479,12 @@ defmodule Kylix.Server.TransactionQueue do
 
           # Update transaction status directly
           now = DateTime.utc_now()
-          updated_statuses = Map.put(current_state.transaction_statuses, ref, %{
+          existing_status = Map.get(current_state.transaction_statuses, ref, %{})
+          updated_statuses = Map.put(current_state.transaction_statuses, ref, existing_status |> Map.merge(%{
+            status: :completed,
             result: result,
             completed_at: now
-          })
+          }))
 
           # Update stats based on result
           new_stats = case result do

--- a/test/server/transaction_queue_test.exs
+++ b/test/server/transaction_queue_test.exs
@@ -162,9 +162,11 @@ defmodule Kylix.Server.TransactionQueueTest do
     # Check final status
     final_status = TransactionQueue.get_transaction_status(ref)
     assert final_status != nil
+    assert final_status.status == :completed
     assert Map.has_key?(final_status, :result)
     assert final_status.result == {:ok, "test_tx_id"}
     assert Map.has_key?(final_status, :completed_at)
+    assert Map.has_key?(final_status, :submitted_at)
   end
 
   # Test that transactions are processed asynchronously with real keys


### PR DESCRIPTION
Fix transaction status updates via direct message by persisting original status keys in `TransactionQueue` using `Map.merge/2`.
Added missing verification keys like `submitted_at` in `test/server/transaction_queue_test.exs`.

---
*PR created automatically by Jules for task [1648544822239141896](https://jules.google.com/task/1648544822239141896) started by @anusornc*