### PR TITLE
🔒 Fix insecure deserialization in DAGEngine

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+erlang 27.2
+elixir 1.18.2-otp-27

--- a/lib/storage/persistent_dag_engine.ex
+++ b/lib/storage/persistent_dag_engine.ex
@@ -77,7 +77,7 @@ defmodule Kylix.Storage.PersistentDAGEngine do
       # Load existing metadata
       metadata_path
       |> File.read!()
-      |> :erlang.binary_to_term()
+      |> :erlang.binary_to_term([:safe])
     else
       # Initialize new metadata
       %{
@@ -124,7 +124,7 @@ defmodule Kylix.Storage.PersistentDAGEngine do
           node_data =
             Path.join(nodes_dir, file)
             |> File.read!()
-            |> :erlang.binary_to_term()
+            |> :erlang.binary_to_term([:safe])
 
           Map.put(acc, node_id, node_data)
         end)
@@ -144,7 +144,7 @@ defmodule Kylix.Storage.PersistentDAGEngine do
           edge_data =
             Path.join(edges_dir, file)
             |> File.read!()
-            |> :erlang.binary_to_term()
+            |> :erlang.binary_to_term([:safe])
 
           case edge_data do
             {from_id, to_id, label} ->
@@ -262,7 +262,7 @@ defmodule Kylix.Storage.PersistentDAGEngine do
           # Read from disk and parse
           node_data =
             File.read!(node_path)
-            |> :erlang.binary_to_term()
+            |> :erlang.binary_to_term([:safe])
 
           # Update cache with this node
           new_cache = %{state.cache | nodes: Map.put(state.cache.nodes, node_id, node_data)}
@@ -301,7 +301,7 @@ defmodule Kylix.Storage.PersistentDAGEngine do
             node_data =
               Path.join([state.db_path, @nodes_dir, file])
               |> File.read!()
-              |> :erlang.binary_to_term()
+              |> :erlang.binary_to_term([:safe])
 
             {node_id, node_data}
           end


### PR DESCRIPTION
🎯 **What:** Fixed an insecure deserialization vulnerability in `lib/storage/persistent_dag_engine.ex` by appending the `[:safe]` option to `:erlang.binary_to_term` calls.
⚠️ **Risk:** The use of `binary_to_term` without the `[:safe]` option allows dynamic allocation of new atoms during deserialization. This could lead to a denial-of-service attack by exhausting the atom table limit, or potentially other insecure deserialization attacks if handling untrusted data.
🛡️ **Solution:** Appended the `[:safe]` option to all five instances of `:erlang.binary_to_term` inside `lib/storage/persistent_dag_engine.ex`.

---
*PR created automatically by Jules for task [1812546729727130065](https://jules.google.com/task/1812546729727130065) started by @anusornc*