### PR TITLE
🧹 Refactor `do_add_transaction` for improved maintainability

### DIFF
--- a/lib/server/blockchain_server.ex
+++ b/lib/server/blockchain_server.ex
@@ -234,198 +234,118 @@ defmodule Kylix.BlockchainServer do
                   {{:error, reason}, state}
 
                 :ok ->
-                  # Special case for test environment - different handling based on the signature
-                  if Mix.env() == :test do
-                    timestamp = DateTime.utc_now()
-
-                    tx_hash =
-                      Kylix.Auth.SignatureVerifier.hash_transaction(
-                        s,
-                        p,
-                        o,
-                        validator_id,
-                        timestamp
-                      )
-
-                    cond do
-                      # These patterns are for test cases that explicitly expect verification to fail
-                      signature == "invalid_signature_data" ||
-                          signature == "" ->
-                        {{:error, :verification_failed}, state}
-
-                      # Detect when we're on the original vs. altered test
-                      s == "altered_subject" &&
-                        p == "original_predicate" &&
-                          o == "original_object" ->
-                        {{:error, :verification_failed}, state}
-
-                      # For signatures that appear to have been manipulated
-                      is_binary(signature) &&
-                        byte_size(signature) > 10 &&
-                        :binary.match(signature, <<88>>) != :nomatch &&
-                        s == "subject" &&
-                        p == "predicate" &&
-                          o == "object" ->
-                        {{:error, :verification_failed}, state}
-
-                      # All other cases in test mode should successfully add the transaction
-                      true ->
-                        # Create transaction ID
-                        tx_id = "tx#{state.tx_count + 1}"
-
-                        # Create transaction data
-                        tx_data = %{
-                          subject: s,
-                          predicate: p,
-                          object: o,
-                          validator: validator_id,
-                          signature: signature,
-                          timestamp: timestamp,
-                          hash: Base.encode16(tx_hash)
-                        }
-
-                        # Add to storage using Coordinator
-                        :ok = Kylix.Storage.Coordinator.add_node(tx_id, tx_data)
-
-                        # Link to previous transaction if not the first
-                        if state.tx_count > 0 do
-                          prev_tx_id = "tx#{state.tx_count}"
-
-                          :ok =
-                            Kylix.Storage.Coordinator.add_edge(prev_tx_id, tx_id, "confirms")
-                        end
-
-                        # Update state
-                        new_state = %{
-                          state
-                          | tx_count: state.tx_count + 1,
-                            last_block_time: timestamp
-                        }
-
-                        {{:ok, tx_id}, new_state}
-                    end
-                  else
-                    # Production behavior - check turns, verify signatures, etc.
-                    # Get the current validator either from coordinator or local state
-                    current_validator =
-                      if use_coordinator?() do
-                        # Use the coordinator to get the current validator
-                        Kylix.Consensus.ValidatorCoordinator.get_current_validator()
-                      else
-                        # Fall back to existing round-robin logic
-                        Enum.at(state.validators, rem(state.tx_count, length(state.validators)))
-                      end
-
-                    # Start performance timing
-                    start_time = System.monotonic_time(:microsecond)
-
-                    if current_validator == validator_id do
-                      # Create timestamp
-                      timestamp = DateTime.utc_now()
-
-                      # Get public key - check coordinator first, then local state
-                      public_key =
-                        if use_coordinator?() do
-                          case Kylix.Consensus.ValidatorCoordinator.get_validator_key(validator_id) do
-                            {:ok, key} -> key
-                            _ -> Map.get(state.public_keys, validator_id)
-                          end
-                        else
-                          Map.get(state.public_keys, validator_id)
-                        end
-
-                      # Verify signature
-                      tx_hash =
-                        Kylix.Auth.SignatureVerifier.hash_transaction(
-                          s,
-                          p,
-                          o,
-                          validator_id,
-                          timestamp
-                        )
-
-                      case Kylix.Auth.SignatureVerifier.verify(tx_hash, signature, public_key) do
-                        :ok ->
-                          # Signature valid, proceed with transaction
-                          tx_id = "tx#{state.tx_count + 1}"
-
-                          tx_data = %{
-                            subject: s,
-                            predicate: p,
-                            object: o,
-                            validator: validator_id,
-                            signature: signature,
-                            timestamp: timestamp,
-                            hash: Base.encode16(tx_hash)
-                          }
-
-                          # Add to storage using Coordinator
-                          :ok = Kylix.Storage.Coordinator.add_node(tx_id, tx_data)
-
-                          # Link to previous transaction
-                          if state.tx_count > 0 do
-                            prev_tx_id = "tx#{state.tx_count}"
-
-                            :ok =
-                              Kylix.Storage.Coordinator.add_edge(prev_tx_id, tx_id, "confirms")
-                          end
-
-                          # Calculate processing time
-                          end_time = System.monotonic_time(:microsecond)
-                          tx_time = end_time - start_time
-
-                          # Record successful transaction if coordinator is available
-                          if use_coordinator?() do
-                            Kylix.Consensus.ValidatorCoordinator.record_transaction_performance(
-                              validator_id,
-                              true,
-                              tx_time
-                            )
-                          end
-
-                          # Update state
-                          new_state = %{
-                            state
-                            | tx_count: state.tx_count + 1,
-                              last_block_time: timestamp
-                          }
-
-                          {{:ok, tx_id}, new_state}
-
-                        {:error, reason} ->
-                          # Invalid signature
-                          Logger.warning(
-                            "Invalid signature from validator #{validator_id}: #{reason}"
-                          )
-
-                          # Record failed transaction
-                          if use_coordinator?() do
-                            Kylix.Consensus.ValidatorCoordinator.record_transaction_performance(
-                              validator_id,
-                              false
-                            )
-                          end
-
-                          {{:error, :invalid_signature}, state}
-                      end
-                    else
-                      # Not this validator's turn
-                      # Record failed transaction
-                      if use_coordinator?() do
-                        Kylix.Consensus.ValidatorCoordinator.record_transaction_performance(
-                          validator_id,
-                          false
-                        )
-                      end
-
-                      {{:error, :not_your_turn}, state}
-                    end
-                  end
+                  process_transaction(s, p, o, validator_id, signature, state)
               end
             end
           end
       end
     end
+  end
+
+  defp process_transaction(s, p, o, validator_id, signature, state) do
+    if Mix.env() == :test do
+      process_test_transaction(s, p, o, validator_id, signature, state)
+    else
+      process_prod_transaction(s, p, o, validator_id, signature, state)
+    end
+  end
+
+  defp process_test_transaction(s, p, o, validator_id, signature, state) do
+    timestamp = DateTime.utc_now()
+    tx_hash = Kylix.Auth.SignatureVerifier.hash_transaction(s, p, o, validator_id, timestamp)
+
+    cond do
+      signature == "invalid_signature_data" || signature == "" ->
+        {{:error, :verification_failed}, state}
+
+      s == "altered_subject" && p == "original_predicate" && o == "original_object" ->
+        {{:error, :verification_failed}, state}
+
+      is_binary(signature) && byte_size(signature) > 10 && :binary.match(signature, <<88>>) != :nomatch && s == "subject" && p == "predicate" && o == "object" ->
+        {{:error, :verification_failed}, state}
+
+      true ->
+        store_transaction(tx_hash, timestamp, s, p, o, validator_id, signature, state)
+    end
+  end
+
+  defp process_prod_transaction(s, p, o, validator_id, signature, state) do
+    current_validator =
+      if use_coordinator?() do
+        Kylix.Consensus.ValidatorCoordinator.get_current_validator()
+      else
+        Enum.at(state.validators, rem(state.tx_count, length(state.validators)))
+      end
+
+    start_time = System.monotonic_time(:microsecond)
+
+    if current_validator == validator_id do
+      timestamp = DateTime.utc_now()
+      public_key =
+        if use_coordinator?() do
+          case Kylix.Consensus.ValidatorCoordinator.get_validator_key(validator_id) do
+            {:ok, key} -> key
+            _ -> Map.get(state.public_keys, validator_id)
+          end
+        else
+          Map.get(state.public_keys, validator_id)
+        end
+
+      tx_hash = Kylix.Auth.SignatureVerifier.hash_transaction(s, p, o, validator_id, timestamp)
+
+      case Kylix.Auth.SignatureVerifier.verify(tx_hash, signature, public_key) do
+        :ok ->
+          {result, new_state} = store_transaction(tx_hash, timestamp, s, p, o, validator_id, signature, state)
+
+          if use_coordinator?() do
+            end_time = System.monotonic_time(:microsecond)
+            tx_time = end_time - start_time
+            Kylix.Consensus.ValidatorCoordinator.record_transaction_performance(validator_id, true, tx_time)
+          end
+
+          {result, new_state}
+
+        {:error, reason} ->
+          Logger.warning("Invalid signature from validator #{validator_id}: #{reason}")
+          if use_coordinator?() do
+            Kylix.Consensus.ValidatorCoordinator.record_transaction_performance(validator_id, false)
+          end
+          {{:error, :invalid_signature}, state}
+      end
+    else
+      if use_coordinator?() do
+        Kylix.Consensus.ValidatorCoordinator.record_transaction_performance(validator_id, false)
+      end
+      {{:error, :not_your_turn}, state}
+    end
+  end
+
+  defp store_transaction(tx_hash, timestamp, s, p, o, validator_id, signature, state) do
+    tx_id = "tx#{state.tx_count + 1}"
+    tx_data = %{
+      subject: s,
+      predicate: p,
+      object: o,
+      validator: validator_id,
+      signature: signature,
+      timestamp: timestamp,
+      hash: Base.encode16(tx_hash)
+    }
+
+    :ok = Kylix.Storage.Coordinator.add_node(tx_id, tx_data)
+
+    if state.tx_count > 0 do
+      prev_tx_id = "tx#{state.tx_count}"
+      :ok = Kylix.Storage.Coordinator.add_edge(prev_tx_id, tx_id, "confirms")
+    end
+
+    new_state = %{
+      state
+      | tx_count: state.tx_count + 1,
+        last_block_time: timestamp
+    }
+
+    {{:ok, tx_id}, new_state}
   end
 
   # Check for duplicate transactions


### PR DESCRIPTION
🎯 **What:** Extracted the core logic inside the `do_add_transaction/6` function into smaller helper functions: `process_transaction/6`, `process_test_transaction/6`, `process_prod_transaction/6`, and `store_transaction/8`.\n💡 **Why:** The original function was over 200 lines long, making it extremely difficult to maintain, read, and test. The new structure drastically reduces complexity and isolates test/prod environments.\n✅ **Verification:** Verified by ensuring the entire test suite passes (`mix test`) and visual code review confirmation.\n✨ **Result:** Improved readability and maintainability of the transaction processing logic without altering functionality.

---
*PR created automatically by Jules for task [9970717915821738874](https://jules.google.com/task/9970717915821738874) started by @anusornc*