### PR TITLE
🧹 refactor: remove leftover IO.inspect in sparql_parser

### DIFF
--- a/lib/query/sparql_parser.ex
+++ b/lib/query/sparql_parser.ex
@@ -321,14 +321,11 @@ defmodule Kylix.Query.SparqlParser do
   Parses a SPARQL query string into a structured query representation.
   """
   def parse(query) do
-    IO.inspect(query, label: "Raw query input to parser")
     try do
       normalized_query = normalize_query(query)
       Logger.debug("Parsing query: #{normalized_query}")
       case parse_query(normalized_query) do
         {:ok, parsed, "", _, _, _} ->
-          IO.inspect(parsed, label: "Parsed before conversion")
-          IO.inspect(parsed, label: "Parsed")
           query_structure = convert_to_query_structure(parsed)
           {:ok, query_structure}
 


### PR DESCRIPTION
🎯 **What:** Removed leftover `IO.inspect` debugging statements from `lib/query/sparql_parser.ex`.
💡 **Why:** `IO.inspect` is typically used for debugging and should not be left in production code. Removing these statements cleans up the codebase and avoids unnecessary console output, which improves maintainability.
✅ **Verification:** Verified that the patch cleanly applies to `lib/query/sparql_parser.ex` and successfully requested a code review. Ran `mix test` and ensured that the remaining test failures are pre-existing issues and not regressions caused by this change.
✨ **Result:** A cleaner and more production-ready SPARQL query parser.

---
*PR created automatically by Jules for task [18273822887141439197](https://jules.google.com/task/18273822887141439197) started by @anusornc*