### PR TITLE
🧹 [code health improvement] Remove leftover IO.inspect statements

### DIFF
--- a/lib/query/sparql_parser.ex
+++ b/lib/query/sparql_parser.ex
@@ -176,7 +176,12 @@ defmodule Kylix.Query.SparqlParser do
       ])
       |> ignore(optional_whitespace)
     )
-    |> lookahead_not(string("GROUP BY") |> string("ORDER BY") |> string("LIMIT") |> string("OFFSET"))
+    |> lookahead_not(
+      string("GROUP BY")
+      |> string("ORDER BY")
+      |> string("LIMIT")
+      |> string("OFFSET")
+    )
     |> tag(:patterns)
 
   defcombinatorp(:inner_patterns_list, inner_patterns_list)
@@ -321,14 +326,12 @@ defmodule Kylix.Query.SparqlParser do
   Parses a SPARQL query string into a structured query representation.
   """
   def parse(query) do
-    IO.inspect(query, label: "Raw query input to parser")
     try do
       normalized_query = normalize_query(query)
       Logger.debug("Parsing query: #{normalized_query}")
+
       case parse_query(normalized_query) do
         {:ok, parsed, "", _, _, _} ->
-          IO.inspect(parsed, label: "Parsed before conversion")
-          IO.inspect(parsed, label: "Parsed")
           query_structure = convert_to_query_structure(parsed)
           {:ok, query_structure}
 


### PR DESCRIPTION
🎯 **What:** Removed leftover `IO.inspect` calls in `lib/query/sparql_parser.ex`.
💡 **Why:** `IO.inspect` is typically used for debugging and clutters the standard output during normal execution and testing. This improves code cleanliness and readability.
✅ **Verification:** Ran test suite to verify no behavior regressions and `mix format` and `mix credo` to ensure the code complies with guidelines.
✨ **Result:** Improved code health by removing debugging statements from production code without modifying any functionality.

---
*PR created automatically by Jules for task [13324780751571273621](https://jules.google.com/task/13324780751571273621) started by @anusornc*