### PR TITLE
Remove outdated is_map() FIX comments

### DIFF
--- a/lib/query/sparql_executor.ex
+++ b/lib/query/sparql_executor.ex
@@ -171,13 +171,11 @@ defmodule Kylix.Query.SparqlExecutor do
         results =
           Enum.reduce(patterns, [%{}], fn pattern, current_solutions ->
             try do
-              # Check for `is_map(pattern)` is already here from a previous fix
               if !is_map(pattern) do
                 Logger.warning("SparqlExecutor: (reduce) non-map pattern: #{inspect(pattern)}. Skipping.")
                 current_solutions 
               else
                 Enum.flat_map(current_solutions, fn solution ->
-                  # Check for `is_map(solution)` is already here from a previous fix
                   if !is_map(solution) do
                     Logger.warning("SparqlExecutor: (flat_map) non-map solution: #{inspect(solution)}. Skipping path.")
                     [] 


### PR DESCRIPTION
Removed two obsolete FIX comments from `lib/query/sparql_executor.ex` which refer to `is_map(pattern)` and `is_map(solution)` previous fixes, as they are no longer useful documentation.

---
*PR created automatically by Jules for task [9229828892962339876](https://jules.google.com/task/9229828892962339876) started by @anusornc*