### PR TITLE
🧪 Add tests for PersistentDAGEngine.handle_call(:add_edge)

### DIFF
--- a/test/storage/persistent_dag_engine_test.exs
+++ b/test/storage/persistent_dag_engine_test.exs
@@ -265,6 +265,74 @@ defmodule Kylix.Storage.PersistentDAGEngineTest do
     end
   end
 
+  describe "handle_call for :add_edge" do
+    setup do
+      state = %{
+        db_path: @test_db_path,
+        metadata: %{
+          last_node_id: "test",
+          node_count: 2,
+          edge_count: 0,
+          last_checkpoint: DateTime.utc_now()
+        },
+        cache: %{
+          nodes: %{"node1" => %{v: 1}, "node2" => %{v: 2}},
+          edges: %{}
+        },
+        query_cache: %{"some_query" => {:result, 12345}}
+      }
+
+      # Create directories and metadata to mimic init
+      File.mkdir_p!(Path.join(@test_db_path, "nodes"))
+      File.mkdir_p!(Path.join(@test_db_path, "edges"))
+
+      metadata_path = Path.join(@test_db_path, "metadata.bin")
+      File.write!(metadata_path, :erlang.term_to_binary(state.metadata))
+
+      {:ok, %{direct_state: state}}
+    end
+
+    test "successfully adds an edge and updates state when nodes exist", %{direct_state: state} do
+      result = PersistentDAGEngine.handle_call({:add_edge, "node1", "node2", "connected"}, {self(), :tag}, state)
+
+      assert {:reply, :ok, new_state} = result
+
+      # Verify cache was updated
+      assert new_state.cache.edges["node1"] == [{"node2", "connected"}]
+
+      # Verify metadata was updated
+      assert new_state.metadata.edge_count == 1
+
+      # Verify query cache was invalidated
+      assert new_state.query_cache == %{}
+
+      # Verify edge was written to disk
+      edge_path = Path.join([@test_db_path, "edges", "node1_node2.bin"])
+      assert File.exists?(edge_path)
+
+      stored_edge =
+        edge_path
+        |> File.read!()
+        |> :erlang.binary_to_term()
+
+      assert stored_edge == {"node1", "node2", "connected"}
+    end
+
+    test "returns error when source node does not exist", %{direct_state: state} do
+      result = PersistentDAGEngine.handle_call({:add_edge, "missing", "node2", "connected"}, {self(), :tag}, state)
+
+      assert {:reply, {:error, :node_not_found}, returned_state} = result
+      assert returned_state == state
+    end
+
+    test "returns error when target node does not exist", %{direct_state: state} do
+      result = PersistentDAGEngine.handle_call({:add_edge, "node1", "missing", "connected"}, {self(), :tag}, state)
+
+      assert {:reply, {:error, :node_not_found}, returned_state} = result
+      assert returned_state == state
+    end
+  end
+
   describe "persistence and recovery" do
     test "data survives process restart" do
       # Add test data


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was an untested public callback function, specifically `handle_call({:add_edge, from_id, to_id, label}, _from, state)`, inside `Kylix.Storage.PersistentDAGEngine`. While `add_edge` was tested via its public API interface indirectly, direct callback coverage was missing.

📊 **Coverage:** The new tests specifically cover direct interactions with the `handle_call({:add_edge, ...})` callback:
- The happy path when both source and target nodes exist, which tests for cache updates, metadata updates, query cache invalidation, and disk persistence.
- The error path when the source node does not exist.
- The error path when the target node does not exist.

✨ **Result:** Test coverage for `PersistentDAGEngine` is improved. By explicitly testing the `handle_call` callback directly, we isolate testing of internal state transformation and I/O side effects, minimizing dependency on the GenServer machinery and making the tests more robust.

---
*PR created automatically by Jules for task [15286029260435528673](https://jules.google.com/task/15286029260435528673) started by @anusornc*