### PR TITLE
🔒 Fix potential atom exhaustion vulnerability in SPARQL parser

### DIFF
--- a/lib/query/sparql_parser.ex
+++ b/lib/query/sparql_parser.ex
@@ -176,7 +176,12 @@ defmodule Kylix.Query.SparqlParser do
       ])
       |> ignore(optional_whitespace)
     )
-    |> lookahead_not(string("GROUP BY") |> string("ORDER BY") |> string("LIMIT") |> string("OFFSET"))
+    |> lookahead_not(
+      string("GROUP BY")
+      |> string("ORDER BY")
+      |> string("LIMIT")
+      |> string("OFFSET")
+    )
     |> tag(:patterns)
 
   defcombinatorp(:inner_patterns_list, inner_patterns_list)
@@ -322,9 +327,11 @@ defmodule Kylix.Query.SparqlParser do
   """
   def parse(query) do
     IO.inspect(query, label: "Raw query input to parser")
+
     try do
       normalized_query = normalize_query(query)
       Logger.debug("Parsing query: #{normalized_query}")
+
       case parse_query(normalized_query) do
         {:ok, parsed, "", _, _, _} ->
           IO.inspect(parsed, label: "Parsed before conversion")
@@ -395,7 +402,7 @@ defmodule Kylix.Query.SparqlParser do
           end
 
         agg = %{
-          function: String.downcase(function) |> String.to_atom(),
+          function: parse_aggregate_function(function),
           variable: var,
           distinct: distinct,
           alias: alias_var
@@ -406,6 +413,38 @@ defmodule Kylix.Query.SparqlParser do
       _, acc ->
         acc
     end)
+  end
+
+  defp parse_aggregate_function(function) do
+    case String.downcase(function) do
+      "count" ->
+        :count
+
+      "sum" ->
+        :sum
+
+      "min" ->
+        :min
+
+      "max" ->
+        :max
+
+      "avg" ->
+        :avg
+
+      "group_concat" ->
+        :group_concat
+
+      other ->
+        try do
+          String.to_existing_atom(other)
+        rescue
+          ArgumentError ->
+            # Raise a more descriptive error instead of creating a new atom
+            # to prevent atom exhaustion on malicious inputs
+            raise ArgumentError, "Unsupported or unknown aggregate function: #{function}"
+        end
+    end
   end
 
   defp process_where_clause(where_items) do


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was an atom exhaustion vulnerability in `lib/query/sparql_parser.ex`. `String.to_atom/1` was called directly on dynamically parsed strings from user input.
⚠️ **Risk:** Converting arbitrary string inputs directly to atoms can quickly exhaust the BEAM VM's atom table limit, leading to an application crash and denial of service (DoS).
🛡️ **Solution:** Implemented a new helper function `parse_aggregate_function/1` that explicitly maps the supported aggregate functions (e.g. "count", "sum") to known atoms using a safe `case` statement. For unknown functions, it safely defaults to using `String.to_existing_atom/1` wrapped in a `try...rescue` block to handle cases where the atom does not exist, raising an explicit `ArgumentError` rather than crashing the BEAM.

---
*PR created automatically by Jules for task [10828797542945352597](https://jules.google.com/task/10828797542945352597) started by @anusornc*