### PR TITLE
🧪 Add test coverage for DAGEngine.clear_all/0

### DIFF
--- a/test/storage/dag_engine_test.exs
+++ b/test/storage/dag_engine_test.exs
@@ -111,6 +111,35 @@ defmodule Kylix.Storage.DAGEngineTest do
     end
   end
 
+  describe "clear_all/0" do
+    test "clears all nodes, edges, and indices from the engine" do
+      # Add several nodes
+      DAGEngine.add_node("node1", %{subject: "Alice", predicate: "knows", object: "Bob"})
+      DAGEngine.add_node("node2", %{subject: "Bob", predicate: "knows", object: "Charlie"})
+
+      # Add edge
+      DAGEngine.add_edge("node1", "node2", "connection")
+
+      # Verify they exist
+      nodes = DAGEngine.get_all_nodes()
+      assert length(nodes) == 2
+
+      {:ok, results} = DAGEngine.query({nil, nil, nil})
+      assert length(results) == 2
+
+      # Call clear_all
+      assert :ok = DAGEngine.clear_all()
+
+      # Verify all nodes are removed
+      nodes_after = DAGEngine.get_all_nodes()
+      assert nodes_after == []
+
+      # Verify query returns empty (meaning edges and indices are also cleared)
+      {:ok, results_after} = DAGEngine.query({nil, nil, nil})
+      assert results_after == []
+    end
+  end
+
   describe "query operations" do
     setup do
       # Create a graph with triple-like structure for testing queries


### PR DESCRIPTION
🎯 **What:** This PR addresses the testing gap for the `clear_all/0` public function in `Kylix.Storage.DAGEngine`. It was identified as an untested public function.

📊 **Coverage:** The new test suite covers the scenario of adding nodes and edges, confirming they exist within the ETS tables and indices, calling `clear_all/0`, and then verifying that both the node list and query results (which rely on indices and edge tables) are completely empty.

✨ **Result:** Test coverage for `DAGEngine` is improved, ensuring the `clear_all/0` function reliably clears internal state as intended without errors.

---
*PR created automatically by Jules for task [563784650621974313](https://jules.google.com/task/563784650621974313) started by @anusornc*