### PR TITLE
🧪 [testing improvement] Add test for DAGEngine.clear_all()

### DIFF
--- a/test/storage/dag_engine_test.exs
+++ b/test/storage/dag_engine_test.exs
@@ -111,6 +111,29 @@ defmodule Kylix.Storage.DAGEngineTest do
     end
   end
 
+  describe "clear_all operations" do
+    test "clear_all removes all nodes, edges, and indexes" do
+      # Add nodes
+      DAGEngine.add_node("tx1", %{subject: "Alice", predicate: "knows", object: "Bob"})
+      DAGEngine.add_node("tx2", %{subject: "Alice", predicate: "likes", object: "Pizza"})
+
+      # Add edge
+      DAGEngine.add_edge("tx1", "tx2", "same_subject")
+
+      # Verify they were added
+      assert length(DAGEngine.get_all_nodes()) == 2
+      {:ok, results} = DAGEngine.query({nil, nil, nil})
+      assert length(results) == 2
+
+      # Clear everything
+      assert :ok = DAGEngine.clear_all()
+
+      # Verify everything is gone
+      assert DAGEngine.get_all_nodes() == []
+      assert {:ok, []} = DAGEngine.query({nil, nil, nil})
+    end
+  end
+
   describe "query operations" do
     setup do
       # Create a graph with triple-like structure for testing queries


### PR DESCRIPTION
🎯 **What:** The `clear_all/0` function in `Kylix.Storage.DAGEngine` was completely untested despite being a public API method.
📊 **Coverage:** A new test block was added in `test/storage/dag_engine_test.exs` that verifies the `clear_all/0` function completely wipes out all nodes, edges, and search indices.
✨ **Result:** Test coverage for `Kylix.Storage.DAGEngine` was improved and behavior of the function is verified.

---
*PR created automatically by Jules for task [15491857040567693178](https://jules.google.com/task/15491857040567693178) started by @anusornc*