### PR TITLE
🧪 [testing] Add test for PersistentDAGEngine.handle_info cache_cleanup

### DIFF
--- a/test/storage/persistent_dag_engine_test.exs
+++ b/test/storage/persistent_dag_engine_test.exs
@@ -265,6 +265,37 @@ defmodule Kylix.Storage.PersistentDAGEngineTest do
     end
   end
 
+  describe "handle_info/2 for cache_cleanup" do
+    test "removes expired cache entries and keeps valid ones" do
+      now = System.system_time(:second)
+
+      # 300 seconds is the TTL
+      valid_timestamp = now - 100
+      expired_timestamp = now - 400
+
+      query_cache = %{
+        "valid_key" => {{"valid_result"}, valid_timestamp},
+        "expired_key" => {{"expired_result"}, expired_timestamp}
+      }
+
+      state = %{
+        db_path: @test_db_path,
+        metadata: %{},
+        cache: %{},
+        query_cache: query_cache
+      }
+
+      assert {:noreply, new_state} = PersistentDAGEngine.handle_info(:cache_cleanup, state)
+
+      # Check that the valid key was kept
+      assert Map.has_key?(new_state.query_cache, "valid_key")
+      assert new_state.query_cache["valid_key"] == {{"valid_result"}, valid_timestamp}
+
+      # Check that the expired key was removed
+      refute Map.has_key?(new_state.query_cache, "expired_key")
+    end
+  end
+
   describe "persistence and recovery" do
     test "data survives process restart" do
       # Add test data


### PR DESCRIPTION
🎯 **What:** Added missing test coverage for `handle_info(:cache_cleanup, state)` in `Kylix.Storage.PersistentDAGEngine`.
📊 **Coverage:** The new test verifies that valid cache entries (with timestamps within the TTL) are kept while expired cache entries (older than the TTL) are correctly removed from the `query_cache`.
✨ **Result:** Increased codebase reliability and coverage by ensuring that the cache eviction logic works as expected without errors.

---
*PR created automatically by Jules for task [15990774381187594343](https://jules.google.com/task/15990774381187594343) started by @anusornc*