### PR TITLE
🧪 Add tests for add_transaction_async and get_queue_status

### DIFF
--- a/test/kylix_test.exs
+++ b/test/kylix_test.exs
@@ -33,6 +33,18 @@ defmodule KylixTest do
     end
   end
 
+  describe "add transaction asynchronously" do
+    test "add transaction asynchronously", %{private_key: private_key} do
+      unique_subject = "subject-async-#{System.monotonic_time()}"
+      timestamp = DateTime.utc_now()
+      tx_hash = hash_transaction(unique_subject, "predicate", "object", "agent1", timestamp)
+      signature = sign(tx_hash, private_key)
+
+      assert {:ok, ref} = Kylix.add_transaction_async(unique_subject, "predicate", "object", "agent1", signature)
+      assert is_reference(ref)
+    end
+  end
+
   describe "add transaction with invalid validator" do
     test "add transaction with invalid validator", %{private_key: private_key} do
       timestamp = DateTime.utc_now()
@@ -51,6 +63,23 @@ defmodule KylixTest do
       {:ok, _tx_id} = Kylix.add_transaction("subject2", "predicate2", "object2", "agent2", signature)
       {:ok, results} = Kylix.query({"subject1", "predicate1", "object1"})
       assert length(results) == 1
+    end
+  end
+
+  describe "get queue status" do
+    test "returns expected map keys" do
+      status = Kylix.get_queue_status()
+      assert is_map(status)
+      assert Map.has_key?(status, :queue_length)
+      assert Map.has_key?(status, :processing)
+      assert Map.has_key?(status, :validators)
+      assert Map.has_key?(status, :current_validator)
+      assert Map.has_key?(status, :batch_size)
+      assert Map.has_key?(status, :processing_interval)
+      assert Map.has_key?(status, :stats)
+      assert Map.has_key?(status, :transaction_count)
+      assert Map.has_key?(status, :pending_count)
+      assert Map.has_key?(status, :completed_count)
     end
   end
 


### PR DESCRIPTION
* 🎯 **What:** The testing gap addressed was that the public function `add_transaction_async/5` (and similarly `get_queue_status/0`) were completely untested in `test/kylix_test.exs`, leaving the API surface potentially fragile.
* 📊 **Coverage:** The scenarios now tested are:
  - Asynchronously submitting a valid transaction with `add_transaction_async/5` and validating the returned reference tuple `{:ok, ref}`.
  - Calling `get_queue_status/0` and verifying it returns the expected data map structure representing internal GenServer queue states.
* ✨ **Result:** The improvement in test coverage secures the entry points to the transaction queue module directly via `Kylix`, boosting confidence against refactoring regressions.

---
*PR created automatically by Jules for task [606242574967356506](https://jules.google.com/task/606242574967356506) started by @anusornc*