### PR TITLE
🧹 [code health] Remove unused `generate_test_keys` in `lib/demo/validator_coordinator_demo.ex`

### DIFF
--- a/lib/demo/validator_coordinator_demo.ex
+++ b/lib/demo/validator_coordinator_demo.ex
@@ -124,20 +124,6 @@ defmodule Kylix.Demo.ValidatorCoordinatorDemo do
     end)
   end
 
-  # defp generate_test_keys(validators, dir) do
-  #   Enum.map(validators, fn validator ->
-  #     # Generate key pair
-  #     {:ok, pub_key, priv_key} = generate_key_pair()
-
-  #     # Save public key
-  #     pub_path = Path.join(dir, "#{validator}.pub")
-  #     File.write!(pub_path, pub_key)
-
-  #     # Return info
-  #     {validator, pub_key, priv_key}
-  #   end)
-  # end
-
   defp generate_key_pair do
     # Use the SignatureVerifier to generate a key pair
     case SignatureVerifier.generate_test_key_pair() do


### PR DESCRIPTION
* 🎯 **What:** The code health issue addressed
  * Removed dead code (commented-out `generate_test_keys/2` function).
* 💡 **Why:** How this improves maintainability
  * Improves codebase readability by cleaning up unused, commented-out code snippets.
* ✅ **Verification:** How you confirmed the change is safe
  * Ran the full test suite (`mix test`) after removal, ensuring there were no negative side effects or regressions. Since it was dead code, there are no references left that could be broken by its deletion.
* ✨ **Result:** The improvement achieved
  * The file `lib/demo/validator_coordinator_demo.ex` is now cleaner.

---
*PR created automatically by Jules for task [7258378376007804538](https://jules.google.com/task/7258378376007804538) started by @anusornc*