### PR TITLE
🧹 Convert IO.inspect to Logger.debug in SparqlParser

### DIFF
--- a/lib/query/sparql_parser.ex
+++ b/lib/query/sparql_parser.ex
@@ -321,14 +321,13 @@ defmodule Kylix.Query.SparqlParser do
   Parses a SPARQL query string into a structured query representation.
   """
   def parse(query) do
-    IO.inspect(query, label: "Raw query input to parser")
+    Logger.debug("Raw query input to parser: #{inspect(query)}")
     try do
       normalized_query = normalize_query(query)
       Logger.debug("Parsing query: #{normalized_query}")
       case parse_query(normalized_query) do
         {:ok, parsed, "", _, _, _} ->
-          IO.inspect(parsed, label: "Parsed before conversion")
-          IO.inspect(parsed, label: "Parsed")
+          Logger.debug("Parsed structure before conversion: #{inspect(parsed)}")
           query_structure = convert_to_query_structure(parsed)
           {:ok, query_structure}
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Converted left-over `IO.inspect` statements inside `SparqlParser.parse/1` to `Logger.debug` calls, formatting variables properly. Duplicate `IO.inspect` calls on the `parsed` variable were merged and properly cleaned up.

💡 **Why:** How this improves maintainability
Debugging print statements like `IO.inspect` shouldn't be left in production code since they clutter standard output. Using `Logger.debug` provides better performance and structured observability that can be turned on or off based on the running environment's log level.

✅ **Verification:** How you confirmed the change is safe
Ran `mix test` and ensured that the tests related to SPARQL parsing execute successfully and that no new regressions were introduced (the tests continued to parse queries without logging the `IO.inspect` standard output). The file was confirmed to already have `Logger` required as it used `Logger.debug` directly under the first set of removed `IO.inspect`s. The removal script `install.sh` from local environment setup was safely deleted so it wouldn't commit.

✨ **Result:** The improvement achieved
A cleaner codebase without unintended trace output in normal operation, while preserving debugging utility via `Logger.debug`.

---
*PR created automatically by Jules for task [6892461030418032377](https://jules.google.com/task/6892461030418032377) started by @anusornc*