### PR TITLE
🔒 Fix insecure deserialization in PersistentDAGEngine

### DIFF
--- a/lib/storage/persistent_dag_engine.ex
+++ b/lib/storage/persistent_dag_engine.ex
@@ -77,7 +77,7 @@ defmodule Kylix.Storage.PersistentDAGEngine do
       # Load existing metadata
       metadata_path
       |> File.read!()
-      |> :erlang.binary_to_term()
+      |> :erlang.binary_to_term([:safe])
     else
       # Initialize new metadata
       %{
@@ -124,7 +124,7 @@ defmodule Kylix.Storage.PersistentDAGEngine do
           node_data =
             Path.join(nodes_dir, file)
             |> File.read!()
-            |> :erlang.binary_to_term()
+            |> :erlang.binary_to_term([:safe])
 
           Map.put(acc, node_id, node_data)
         end)
@@ -144,7 +144,7 @@ defmodule Kylix.Storage.PersistentDAGEngine do
           edge_data =
             Path.join(edges_dir, file)
             |> File.read!()
-            |> :erlang.binary_to_term()
+            |> :erlang.binary_to_term([:safe])
 
           case edge_data do
             {from_id, to_id, label} ->
@@ -262,7 +262,7 @@ defmodule Kylix.Storage.PersistentDAGEngine do
           # Read from disk and parse
           node_data =
             File.read!(node_path)
-            |> :erlang.binary_to_term()
+            |> :erlang.binary_to_term([:safe])
 
           # Update cache with this node
           new_cache = %{state.cache | nodes: Map.put(state.cache.nodes, node_id, node_data)}
@@ -301,7 +301,7 @@ defmodule Kylix.Storage.PersistentDAGEngine do
             node_data =
               Path.join([state.db_path, @nodes_dir, file])
               |> File.read!()
-              |> :erlang.binary_to_term()
+              |> :erlang.binary_to_term([:safe])
 
             {node_id, node_data}
           end


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is insecure deserialization when reading files from disk. The codebase was calling `:erlang.binary_to_term()` without the `[:safe]` option.

⚠️ **Risk:** If an attacker can control the contents of the files being read, they can craft malicious binaries that cause Erlang to generate new atoms dynamically. Because the atom table is not garbage-collected and has a strict upper limit, this can quickly lead to atom exhaustion, crashing the application (Denial of Service).

🛡️ **Solution:** The fix replaces all calls to `:erlang.binary_to_term/1` in `lib/storage/persistent_dag_engine.ex` with `:erlang.binary_to_term/2` using the `[:safe]` option. This option ensures that existing atoms are matched, but no new atoms are generated during deserialization. Deserialization of payloads containing unknown atoms will cleanly fail instead of exhausting memory.

---
*PR created automatically by Jules for task [15313914250469850098](https://jules.google.com/task/15313914250469850098) started by @anusornc*