### PR TITLE
Update DATABASE_PATH example

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -4,7 +4,7 @@ if config_env() == :prod do
   # Allow runtime configuration in production
   # This will let you set configuration via environment variables
 
-  # Example: DATABASE_PATH=xxx mix run
+  # Example: DATABASE_PATH=/path/to/db mix run
   if db_path = System.get_env("DATABASE_PATH") do
     config :kylix, db_path: db_path
   end


### PR DESCRIPTION
Update the example value used for `DATABASE_PATH` in `config/runtime.exs` so it is not incorrectly flagged as a TODO by scripts searching for `xxx`.

---
*PR created automatically by Jules for task [7652613064215373945](https://jules.google.com/task/7652613064215373945) started by @anusornc*