### PR TITLE
🔒 Fix insecure deserialization in PersistentDAGEngine

### DIFF
--- a/lib/storage/persistent_dag_engine.ex
+++ b/lib/storage/persistent_dag_engine.ex
@@ -77,7 +77,7 @@ defmodule Kylix.Storage.PersistentDAGEngine do
       # Load existing metadata
       metadata_path
       |> File.read!()
-      |> :erlang.binary_to_term()
+      |> :erlang.binary_to_term([:safe])
     else
       # Initialize new metadata
       %{
@@ -124,7 +124,7 @@ defmodule Kylix.Storage.PersistentDAGEngine do
           node_data =
             Path.join(nodes_dir, file)
             |> File.read!()
-            |> :erlang.binary_to_term()
+            |> :erlang.binary_to_term([:safe])
 
           Map.put(acc, node_id, node_data)
         end)
@@ -144,7 +144,7 @@ defmodule Kylix.Storage.PersistentDAGEngine do
           edge_data =
             Path.join(edges_dir, file)
             |> File.read!()
-            |> :erlang.binary_to_term()
+            |> :erlang.binary_to_term([:safe])
 
           case edge_data do
             {from_id, to_id, label} ->
@@ -262,7 +262,7 @@ defmodule Kylix.Storage.PersistentDAGEngine do
           # Read from disk and parse
           node_data =
             File.read!(node_path)
-            |> :erlang.binary_to_term()
+            |> :erlang.binary_to_term([:safe])
 
           # Update cache with this node
           new_cache = %{state.cache | nodes: Map.put(state.cache.nodes, node_id, node_data)}
@@ -301,7 +301,7 @@ defmodule Kylix.Storage.PersistentDAGEngine do
             node_data =
               Path.join([state.db_path, @nodes_dir, file])
               |> File.read!()
-              |> :erlang.binary_to_term()
+              |> :erlang.binary_to_term([:safe])
 
             {node_id, node_data}
           end


### PR DESCRIPTION
🎯 **What:** Fixed insecure deserialization vulnerabilities in `Kylix.Storage.PersistentDAGEngine`.
⚠️ **Risk:** The previous code used `:erlang.binary_to_term/1` without the `[:safe]` option to deserialize data from disk. If an attacker could influence or tamper with the files stored on disk (e.g., node data, edge data, or metadata), they could force the Erlang VM to deserialize terms containing new atoms. Since the atom table is not garbage collected, an attacker could trigger atom exhaustion, causing the Erlang VM to crash (Denial of Service).
🛡️ **Solution:** Replaced all 5 occurrences of `:erlang.binary_to_term()` with `:erlang.binary_to_term([:safe])` across the `PersistentDAGEngine` module. The `[:safe]` flag ensures that only existing atoms in the VM's atom table are decoded. If the payload contains unknown atoms, it will securely raise an exception rather than exhausting the atom table. Tests were successfully run to verify the changes introduced no functional regressions.

---
*PR created automatically by Jules for task [9219160048429965487](https://jules.google.com/task/9219160048429965487) started by @anusornc*