### PR TITLE
🧹 [Code Health] Remove unused `_var_positions` in SPARQL executor

### DIFF
--- a/lib/query/sparql_executor.ex
+++ b/lib/query/sparql_executor.ex
@@ -526,19 +526,14 @@ defmodule Kylix.Query.SparqlExecutor do
     end
   end
 
-  defp project_variables(results, variables, query_structure) do
+  defp project_variables(results, variables, _query_structure) do
     projected = Enum.map(results, fn binding ->
-      create_projection(binding, variables, query_structure)
+      create_projection(binding, variables)
     end)
     {:ok, projected}
   end
 
-  defp create_projection(binding, variables_in_select, query_structure) do
-    # var_positions might be useful if populated by SparqlEngine using VariableMapper.extract_variable_positions
-    # For now, let's assume variables_in_select are like "?var"
-    # and binding contains results from merge_bindings which should have keys like "?var" and also "role" names.
-    _var_positions = Map.get(query_structure, :variable_positions, %{}) # Keep if needed later, suppress warning for now
-
+  defp create_projection(binding, variables_in_select) do
     Enum.reduce(variables_in_select, %{}, fn var_with_q_mark, projected_map ->
       # Default projected key is the variable name without '?'
       proj_key = String.trim_leading(var_with_q_mark, "?")


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed the unused `_var_positions` assignment and its accompanying outdated comments in `create_projection` in `lib/query/sparql_executor.ex`. Also removed the unused `query_structure` parameter passed to `create_projection`, updating its call site inside `project_variables`.

💡 **Why:** How this improves maintainability
The assignment was noisy, unused, and cluttered the function. Removing it and the unused parameter makes the `create_projection` logic cleaner and strictly focused on reducing over `variables_in_select`.

✅ **Verification:** How you confirmed the change is safe
Ran `mix test test/query/sparql_executor_test.exs` and `mix test`. No new regressions were introduced (the overall test suite failures are known pre-existing ones). Code changes are safely contained as the modifications were made inside private functions (`defp`).

✨ **Result:** The improvement achieved
A simpler, cleaner projection function with no unnecessary map lookups or unneeded parameters.

---
*PR created automatically by Jules for task [12078644368378231551](https://jules.google.com/task/12078644368378231551) started by @anusornc*