### PR TITLE
🧹 Replace IO.inspect with Logger.debug in SPARQL parser

### DIFF
--- a/lib/query/sparql_parser.ex
+++ b/lib/query/sparql_parser.ex
@@ -321,14 +321,13 @@ defmodule Kylix.Query.SparqlParser do
   Parses a SPARQL query string into a structured query representation.
   """
   def parse(query) do
-    IO.inspect(query, label: "Raw query input to parser")
+    Logger.debug("Raw query input to parser: #{inspect(query)}")
     try do
       normalized_query = normalize_query(query)
       Logger.debug("Parsing query: #{normalized_query}")
       case parse_query(normalized_query) do
         {:ok, parsed, "", _, _, _} ->
-          IO.inspect(parsed, label: "Parsed before conversion")
-          IO.inspect(parsed, label: "Parsed")
+          Logger.debug("Parsed: #{inspect(parsed)}")
           query_structure = convert_to_query_structure(parsed)
           {:ok, query_structure}
 


### PR DESCRIPTION
🎯 **What:** Replaced leftover `IO.inspect` calls in `lib/query/sparql_parser.ex` with standard `Logger.debug` logs.

💡 **Why:** `IO.inspect` dumps state directly to standard output, making the terminal/production logs noisy and non-standard. Replacing it with Elixir's `Logger.debug` allows logs to be correctly captured, formatted, and suppressed if needed in production environments, improving overall maintainability.

✅ **Verification:** Verified by running the test suite (`mix test`). The tests pass (excluding pre-existing issues noted in `sparql_engine_test.exs`), ensuring the behavior itself remains identical but the console output is properly captured via logging.

✨ **Result:** Cleaned up output standardizing on the system's `Logger`, eliminating raw stdio outputs during standard query parsing operations.

---
*PR created automatically by Jules for task [9699008502477681802](https://jules.google.com/task/9699008502477681802) started by @anusornc*