### PR TITLE
🧹 Remove placeholder logic in Consensus.current_round

### DIFF
--- a/lib/consensus.ex
+++ b/lib/consensus.ex
@@ -31,9 +31,7 @@ defmodule Kylix.Consensus do
     # Get status from blockchain server for transaction count
     if Process.whereis(Kylix.BlockchainServer) do
       try do
-        # The transaction count would be equivalent to the round number
-        # We'll need to add an API to get this from the BlockchainServer
-        0  # Placeholder until proper API exists
+        Kylix.BlockchainServer.get_tx_count()
       rescue
         _ -> 0
       end

--- a/lib/server/blockchain_server.ex
+++ b/lib/server/blockchain_server.ex
@@ -65,6 +65,12 @@ defmodule Kylix.BlockchainServer do
     GenServer.call(__MODULE__, {:query, pattern})
   end
 
+  # Get the current transaction count (equivalent to the current round)
+  @spec get_tx_count() :: non_neg_integer()
+  def get_tx_count() do
+    GenServer.call(__MODULE__, :get_tx_count)
+  end
+
   # Get the list of current validators in the blockchain
   # Returns a list of validator identifiers
   @spec get_validators() :: [String.t()]
@@ -115,6 +121,11 @@ defmodule Kylix.BlockchainServer do
   @impl true
   def handle_call(:get_test_key_pair, _from, state) do
     {:reply, {:ok, state.test_key_pair}, state}
+  end
+
+  @impl true
+  def handle_call(:get_tx_count, _from, state) do
+    {:reply, state.tx_count, state}
   end
 
   @impl true


### PR DESCRIPTION
🎯 **What:** Removed placeholder logic from `Kylix.Consensus.current_round` by fetching the actual transaction count via a newly created `get_tx_count` function in `Kylix.BlockchainServer`.
💡 **Why:** This resolves pending technical debt and allows the application's actual transaction count to correctly drive logic relying on the current consensus round.
✅ **Verification:** Added the server function, inspected the implementation with test suite running without regression, and ensured that fallback behavior (`try/rescue`) safely maintains zero-default behavior.
✨ **Result:** Improved system completeness and proper behavior regarding reporting the consensus round.

---
*PR created automatically by Jules for task [6422445104059341506](https://jules.google.com/task/6422445104059341506) started by @anusornc*