### PR TITLE
🔒 Fix insecure deserialization in PersistentDAGEngine

### DIFF
--- a/lib/storage/persistent_dag_engine.ex
+++ b/lib/storage/persistent_dag_engine.ex
@@ -77,7 +77,7 @@ defmodule Kylix.Storage.PersistentDAGEngine do
       # Load existing metadata
       metadata_path
       |> File.read!()
-      |> :erlang.binary_to_term()
+      |> :erlang.binary_to_term([:safe])
     else
       # Initialize new metadata
       %{
@@ -124,7 +124,7 @@ defmodule Kylix.Storage.PersistentDAGEngine do
           node_data =
             Path.join(nodes_dir, file)
             |> File.read!()
-            |> :erlang.binary_to_term()
+            |> :erlang.binary_to_term([:safe])
 
           Map.put(acc, node_id, node_data)
         end)
@@ -144,7 +144,7 @@ defmodule Kylix.Storage.PersistentDAGEngine do
           edge_data =
             Path.join(edges_dir, file)
             |> File.read!()
-            |> :erlang.binary_to_term()
+            |> :erlang.binary_to_term([:safe])
 
           case edge_data do
             {from_id, to_id, label} ->
@@ -262,7 +262,7 @@ defmodule Kylix.Storage.PersistentDAGEngine do
           # Read from disk and parse
           node_data =
             File.read!(node_path)
-            |> :erlang.binary_to_term()
+            |> :erlang.binary_to_term([:safe])
 
           # Update cache with this node
           new_cache = %{state.cache | nodes: Map.put(state.cache.nodes, node_id, node_data)}
@@ -301,7 +301,7 @@ defmodule Kylix.Storage.PersistentDAGEngine do
             node_data =
               Path.join([state.db_path, @nodes_dir, file])
               |> File.read!()
-              |> :erlang.binary_to_term()
+              |> :erlang.binary_to_term([:safe])
 
             {node_id, node_data}
           end

--- a/test/storage/persistent_dag_engine_test.exs
+++ b/test/storage/persistent_dag_engine_test.exs
@@ -57,7 +57,7 @@ defmodule Kylix.Storage.PersistentDAGEngineTest do
       stored_data =
         node_path
         |> File.read!()
-        |> :erlang.binary_to_term()
+        |> :erlang.binary_to_term([:safe])
 
       assert stored_data == data
     end
@@ -125,7 +125,7 @@ defmodule Kylix.Storage.PersistentDAGEngineTest do
       stored_edge =
         edge_path
         |> File.read!()
-        |> :erlang.binary_to_term()
+        |> :erlang.binary_to_term([:safe])
 
       assert stored_edge == {"source", "target", "connects"}
 


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was insecure deserialization of term data from files using `:erlang.binary_to_term()`.
⚠️ **Risk:** The potential impact if left unfixed is atom exhaustion, which can lead to a Denial of Service (DoS) attack, or in worse scenarios, execution of untrusted code via maliciously crafted terms.
🛡️ **Solution:** Used `:erlang.binary_to_term/2` with the `[:safe]` option to safely decode terms, throwing `ArgumentError` if unknown atoms or malicious data are found. Fixed the issues in `lib/storage/persistent_dag_engine.ex` and `test/storage/persistent_dag_engine_test.exs`.

---
*PR created automatically by Jules for task [17488301815341255896](https://jules.google.com/task/17488301815341255896) started by @anusornc*