### PR TITLE
🔒 Fix Atom Exhaustion vulnerability in SPARQL parser

### DIFF
--- a/lib/query/sparql_parser.ex
+++ b/lib/query/sparql_parser.ex
@@ -394,8 +394,19 @@ defmodule Kylix.Query.SparqlParser do
             nil -> "#{String.downcase(function)}_#{var}"
           end
 
+        function_atom =
+          case String.downcase(function) do
+            "count" -> :count
+            "sum" -> :sum
+            "avg" -> :avg
+            "min" -> :min
+            "max" -> :max
+            "group_concat" -> :group_concat
+            _ -> :unknown_aggregate
+          end
+
         agg = %{
-          function: String.downcase(function) |> String.to_atom(),
+          function: function_atom,
           variable: var,
           distinct: distinct,
           alias: alias_var


### PR DESCRIPTION
🎯 **What:** The `String.to_atom/1` function in `lib/query/sparql_parser.ex` was used to dynamically convert parsed string aggregate functions from user input into atoms.
⚠️ **Risk:** Because Erlang atoms are not garbage collected, a malicious user or malformed input could continually pass unique, non-existent function names, which would steadily exhaust the VM's atom table limit and eventually crash the node (Denial of Service).
🛡️ **Solution:** Replaced `String.to_atom/1` with a `case` statement that strictly maps expected, lowercased string values (e.g., `"count"`, `"sum"`) to their corresponding known atoms. Any unknown strings safely fall back to `:unknown_aggregate` without allocating new atoms.

---
*PR created automatically by Jules for task [11310526038159716653](https://jules.google.com/task/11310526038159716653) started by @anusornc*